### PR TITLE
Fixed ArgumentNullException on Webserver.Dispose

### DIFF
--- a/src/WatsonWebserver/Webserver.cs
+++ b/src/WatsonWebserver/Webserver.cs
@@ -176,12 +176,8 @@ namespace WatsonWebserver
 
                 _HttpListener = null;
                 Settings = null;
-                Routes = null;
                 _TokenSource = null;
                 _AcceptConnections = null;
-
-                Events = null;
-                Statistics = null;
             }
         }
 


### PR DESCRIPTION
Calling Webserver.Dispose() sets a few properties to null which triggers an ArgumentNullException in WebserverBase. This PR removes the lines which cause the issue.
