### PR TITLE
Add URL encoding support and index.html automatic mapping support in ContentRouteHandler

### DIFF
--- a/src/WatsonWebserver.Core/ContentRouteManager.cs
+++ b/src/WatsonWebserver.Core/ContentRouteManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -273,7 +274,11 @@ namespace WatsonWebserver.Core
 
             filePath = baseDirectory + filePath;
             filePath = filePath.Replace("+", " ").Replace("%20", " ");
-
+            if (filePath.EndsWith("/"))
+            {
+                filePath += "index.html";
+            }
+            filePath = WebUtility.UrlDecode(filePath);
             string contentType = GetContentType(filePath);
 
             if (!File.Exists(filePath))


### PR DESCRIPTION
Add the following code after [here](https://github.com/dotnet/WatsonWebserver/blob/8d129b63811bf900ea63d2f153017541fc487fea/src/WatsonWebserver.Core/ContentRouteManager.cs#L277C7-L277C7):

```c#
if (filePath.EndsWith("/"))
{
    filePath += "index.html";
}
filePath = WebUtility.UrlDecode(filePath);
```
After adding the above code, my Vitespress documentation website can now function properly.