### PR TITLE
Watson.Lite: Fixes Client Stream crashing webserver if client closed the wire.

### DIFF
--- a/src/WatsonWebserver.Lite/HttpResponse.cs
+++ b/src/WatsonWebserver.Lite/HttpResponse.cs
@@ -601,30 +601,22 @@ namespace WatsonWebserver.Lite
                 byte[] buffer = new byte[_StreamBufferSize];
                 int bytesToRead = _StreamBufferSize;
                 int bytesRead = 0;
-
-                while (bytesRemaining > 0)
-                {
-                    if (bytesRemaining > _StreamBufferSize) bytesToRead = _StreamBufferSize;
-                    else bytesToRead = (int)bytesRemaining;
-
-                    bytesRead = await stream.ReadAsync(buffer, 0, bytesToRead, token).ConfigureAwait(false);
-                    if (bytesRead > 0)
-                    { 
-                        try
-                        {
-                            await _Stream.WriteAsync(buffer, 0, bytesRead, token).ConfigureAwait(false);
-                        }
-                        catch (ObjectDisposedException)
-                        {
-                            /* Always check if the stream is disposed, some clients are picky about this and cut the wire in the middle of a request.
-                             * C# documentation explicitly mention catching the disposed object, as we cannot know in advance if the stream is disposed. */
-                        }
-                        bytesRemaining -= bytesRead;
-                    }
-                }
                  
                 try
                 {
+                    while (bytesRemaining > 0)
+                    {
+                        if (bytesRemaining > _StreamBufferSize) bytesToRead = _StreamBufferSize;
+                        else bytesToRead = (int)bytesRemaining;
+
+                        bytesRead = await stream.ReadAsync(buffer, 0, bytesToRead, token).ConfigureAwait(false);
+                        if (bytesRead > 0)
+                        { 
+                            await _Stream.WriteAsync(buffer, 0, bytesRead, token).ConfigureAwait(false);
+                            bytesRemaining -= bytesRead;
+                        }
+                    }
+				
                     await _Stream.FlushAsync(token).ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException)

--- a/src/WatsonWebserver.Lite/HttpResponse.cs
+++ b/src/WatsonWebserver.Lite/HttpResponse.cs
@@ -585,13 +585,13 @@ namespace WatsonWebserver.Lite
                 {
                     await _Stream.WriteAsync(headers, 0, headers.Length, token).ConfigureAwait(false);
                     await _Stream.FlushAsync(token).ConfigureAwait(false);
+                    _HeadersSent = true; // We use the flag at our advantage, so we can effectively check for dead wires.
                 }
                 catch (ObjectDisposedException)
                 {
                     /* Always check if the stream is disposed, some clients are picky about this and cut the wire in the middle of a request.
                      * C# documentation explicitly mention catching the disposed object, as we cannot know in advance if the stream is disposed. */
                 }
-                _HeadersSent = true;
             }
 
             if (contentLength > 0 && stream != null && stream.CanRead)
@@ -631,13 +631,14 @@ namespace WatsonWebserver.Lite
                 try
                 {
                     _Stream.Close();
+                    ResponseSent = true; /* We use the flag at our advantage, so we can effectively check for dead wires, sounds a bit unsafe,
+                                          * at this specific place but we can assume the stream was cut if the closing operation didn't complete. */
                 }
                 catch (ObjectDisposedException)
                 {
                     /* Always check if the stream is disposed, some clients are picky about this and cut the wire in the middle of a request.
                      * C# documentation explicitly mention catching the disposed object, as we cannot know in advance if the stream is disposed. */
                 }
-                ResponseSent = true;
             }
 
             return true;

--- a/src/WatsonWebserver.Lite/HttpResponse.cs
+++ b/src/WatsonWebserver.Lite/HttpResponse.cs
@@ -588,7 +588,8 @@ namespace WatsonWebserver.Lite
                 }
                 catch (ObjectDisposedException)
                 {
-                    // Always check if the stream is disposed, some clients are picky about this and cut the wire in the middle of a request.
+                    /* Always check if the stream is disposed, some clients are picky about this and cut the wire in the middle of a request.
+                     * C# documentation explicitly mention catching the disposed object, as we cannot know in advance if the stream is disposed. */
                 }
                 _HeadersSent = true;
             }


### PR DESCRIPTION
Watson.Lite: Fixes Client Stream crashing webserver if client closed the wire.

This fixes the issue according to the recommendations of the C# documentation.

The issue always existed even in httpserverlite, but somehow it was masked before...