### PR TITLE
Fixed typo in IHostBuilder.MapParameteRoute

### DIFF
--- a/src/Test.HostBuilder/Program.cs
+++ b/src/Test.HostBuilder/Program.cs
@@ -45,7 +45,7 @@ namespace Test.HostBuilder
                         await ctx.Response.Send();
                         return;
                     }, false)
-                    .MapParameteRoute(HttpMethod.GET, "/preauth/parameter/{id}", async (HttpContextBase ctx) =>
+                    .MapParameterRoute(HttpMethod.GET, "/preauth/parameter/{id}", async (HttpContextBase ctx) =>
                     {
                         Console.WriteLine("| Responding from pre-authentication parameter route /preauth/parameter/" + ctx.Request.Url.Parameters["id"]);
                         await ctx.Response.Send();
@@ -65,7 +65,7 @@ namespace Test.HostBuilder
                         await ctx.Response.Send();
                         return;
                     }, false)
-                    .MapParameteRoute(HttpMethod.GET, "/postauth/parameter/{id}", async (HttpContextBase ctx) =>
+                    .MapParameterRoute(HttpMethod.GET, "/postauth/parameter/{id}", async (HttpContextBase ctx) =>
                     {
                         Console.WriteLine("| Responding from post-authentication parameter route /postauth/parameter/" + ctx.Request.Url.Parameters["id"]);
                         await ctx.Response.Send();
@@ -92,7 +92,7 @@ namespace Test.HostBuilder
                         await ctx.Response.Send();
                         return;
                     }, false)
-                    .MapParameteRoute(HttpMethod.GET, "/preauth/parameter/{id}", async (HttpContextBase ctx) =>
+                    .MapParameterRoute(HttpMethod.GET, "/preauth/parameter/{id}", async (HttpContextBase ctx) =>
                     {
                         Console.WriteLine("| Responding from pre-authentication parameter route /preauth/parameter/" + ctx.Request.Url.Parameters["id"]);
                         await ctx.Response.Send();
@@ -112,7 +112,7 @@ namespace Test.HostBuilder
                         await ctx.Response.Send();
                         return;
                     }, true)
-                    .MapParameteRoute(HttpMethod.GET, "/postauth/parameter/{id}", async (HttpContextBase ctx) =>
+                    .MapParameterRoute(HttpMethod.GET, "/postauth/parameter/{id}", async (HttpContextBase ctx) =>
                     {
                         Console.WriteLine("| Responding from post-authentication parameter route /postauth/parameter/" + ctx.Request.Url.Parameters["id"]);
                         await ctx.Response.Send();

--- a/src/WatsonWebserver.Core/IHostBuilder.cs
+++ b/src/WatsonWebserver.Core/IHostBuilder.cs
@@ -73,8 +73,19 @@ namespace WatsonWebserver.Core
         /// <param name="action">Action.</param>
         /// <param name="requiresAuthentication">Flag to indicate whether or not the route requires authentication.</param>
         /// <returns>Host builder.</returns>
+        [Obsolete("Use MapParameterRoute instead.")]
         HostBuilder MapParameteRoute(HttpMethod method, string path, InputAction action, bool requiresAuthentication = false);
 
+        /// <summary>
+        /// Apply a parameter route.
+        /// </summary>
+        /// <param name="method">HTTP method.</param>
+        /// <param name="path">Route path.</param>
+        /// <param name="action">Action.</param>
+        /// <param name="requiresAuthentication">Flag to indicate whether or not the route requires authentication.</param>
+        /// <returns>Host builder.</returns>
+        HostBuilder MapParameterRoute(HttpMethod method, string path, InputAction action, bool requiresAuthentication = false);
+        
         /// <summary>
         /// Apply a dynamic route.
         /// </summary>

--- a/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
+++ b/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
@@ -973,6 +973,16 @@
             <param name="requiresAuthentication">Flag to indicate whether or not the route requires authentication.</param>
             <returns>Host builder.</returns>
         </member>
+        <member name="M:WatsonWebserver.Core.IHostBuilder`2.MapParameterRoute(WatsonWebserver.Core.HttpMethod,System.String,`1,System.Boolean)">
+            <summary>
+                Apply a parameter route.
+            </summary>
+            <param name="method">HTTP method.</param>
+            <param name="path">Route path.</param>
+            <param name="action">Action.</param>
+            <param name="requiresAuthentication">Flag to indicate whether or not the route requires authentication.</param>
+            <returns>Host builder.</returns>
+        </member>
         <member name="M:WatsonWebserver.Core.IHostBuilder`2.MapDynamicRoute(WatsonWebserver.Core.HttpMethod,System.Text.RegularExpressions.Regex,`1,System.Boolean)">
             <summary>
             Apply a dynamic route.

--- a/src/WatsonWebserver.Lite/Extensions/HostBuilderExtension/HostBuilder.cs
+++ b/src/WatsonWebserver.Lite/Extensions/HostBuilderExtension/HostBuilder.cs
@@ -172,6 +172,19 @@ namespace WatsonWebserver.Lite.Extensions.HostBuilderExtension
         /// <returns>Host builder.</returns>
         public HostBuilder MapParameteRoute(HttpMethod method, string path, Func<HttpContextBase, Task> action, bool requiresAuthentication = false)
         {
+            return MapParameterRoute(method, path, action, requiresAuthentication);
+        }
+        
+        /// <summary>
+        /// Apply a parameter route.
+        /// </summary>
+        /// <param name="method">HTTP method.</param>
+        /// <param name="path">Route path.</param>
+        /// <param name="action">Action.</param>
+        /// <param name="requiresAuthentication">Boolean to indicate if the route requires authentication.</param>
+        /// <returns>Host builder.</returns>
+        public HostBuilder MapParameterRoute(HttpMethod method, string path, Func<HttpContextBase, Task> action, bool requiresAuthentication = false)
+        {
             if (!requiresAuthentication)
                 Server.Routes.PreAuthentication.Parameter.Add(method, path, action);
             else

--- a/src/WatsonWebserver.Lite/WatsonWebserver.Lite.xml
+++ b/src/WatsonWebserver.Lite/WatsonWebserver.Lite.xml
@@ -85,6 +85,16 @@
             <param name="requiresAuthentication">Boolean to indicate if the route requires authentication.</param>
             <returns>Host builder.</returns>
         </member>
+        <member name="M:WatsonWebserver.Lite.Extensions.HostBuilderExtension.HostBuilder.MapParameterRoute(WatsonWebserver.Core.HttpMethod,System.String,System.Func{WatsonWebserver.Core.HttpContextBase,System.Threading.Tasks.Task},System.Boolean)">
+            <summary>
+                Apply a parameter route.
+            </summary>
+            <param name="method">HTTP method.</param>
+            <param name="path">Route path.</param>
+            <param name="action">Action.</param>
+            <param name="requiresAuthentication">Boolean to indicate if the route requires authentication.</param>
+            <returns>Host builder.</returns>
+        </member>
         <member name="M:WatsonWebserver.Lite.Extensions.HostBuilderExtension.HostBuilder.MapDynamicRoute(WatsonWebserver.Core.HttpMethod,System.Text.RegularExpressions.Regex,System.Func{WatsonWebserver.Core.HttpContextBase,System.Threading.Tasks.Task},System.Boolean)">
             <summary>
             Apply a dynamic route.

--- a/src/WatsonWebserver/Extensions/HostBuilderExtension/HostBuilder.cs
+++ b/src/WatsonWebserver/Extensions/HostBuilderExtension/HostBuilder.cs
@@ -172,6 +172,19 @@ namespace WatsonWebserver.Extensions.HostBuilderExtension
         /// <returns>Host builder.</returns>
         public HostBuilder MapParameteRoute(HttpMethod method, string path, Func<HttpContextBase, Task> action, bool requiresAuthentication = false)
         {
+            return MapParameterRoute(method, path, action, requiresAuthentication);
+        }
+        
+        /// <summary>
+        /// Apply a parameter route.
+        /// </summary>
+        /// <param name="method">HTTP method.</param>
+        /// <param name="path">Route path.</param>
+        /// <param name="action">Action.</param>
+        /// <param name="requiresAuthentication">Boolean to indicate if the route requires authentication.</param>
+        /// <returns>Host builder.</returns>
+        public HostBuilder MapParameterRoute(HttpMethod method, string path, Func<HttpContextBase, Task> action, bool requiresAuthentication = false)
+        {
             if (!requiresAuthentication)
                 Server.Routes.PreAuthentication.Parameter.Add(method, path, action);
             else

--- a/src/WatsonWebserver/WatsonWebserver.xml
+++ b/src/WatsonWebserver/WatsonWebserver.xml
@@ -85,6 +85,16 @@
             <param name="requiresAuthentication">Boolean to indicate if the route requires authentication.</param>
             <returns>Host builder.</returns>
         </member>
+        <member name="M:WatsonWebserver.Extensions.HostBuilderExtension.HostBuilder.MapParameterRoute(WatsonWebserver.Core.HttpMethod,System.String,System.Func{WatsonWebserver.Core.HttpContextBase,System.Threading.Tasks.Task},System.Boolean)">
+            <summary>
+                Apply a parameter route.
+            </summary>
+            <param name="method">HTTP method.</param>
+            <param name="path">Route path.</param>
+            <param name="action">Action.</param>
+            <param name="requiresAuthentication">Boolean to indicate if the route requires authentication.</param>
+            <returns>Host builder.</returns>
+        </member>
         <member name="M:WatsonWebserver.Extensions.HostBuilderExtension.HostBuilder.MapDynamicRoute(WatsonWebserver.Core.HttpMethod,System.Text.RegularExpressions.Regex,System.Func{WatsonWebserver.Core.HttpContextBase,System.Threading.Tasks.Task},System.Boolean)">
             <summary>
             Apply a dynamic route.


### PR DESCRIPTION
It seems the 'r' at the end of 'Parameter' was merged with the 'R' at the start of 'Route' 😄

I deprecated the old method name and created a new one with the corrected name. No functionality was changed, these are backward-compatible changes.