### PR TITLE
CRITICAL: Fixes a Watson/Lite crashing issue with Concurrent Streams.

### DIFF
--- a/src/WatsonWebserver.Lite/Webserver.cs
+++ b/src/WatsonWebserver.Lite/Webserver.cs
@@ -618,7 +618,10 @@ namespace WatsonWebserver.Lite
                 {
                     ctx.Response.StatusCode = 404;
                     ctx.Response.ContentType = DefaultPages.Pages[404].ContentType;
-                    await ctx.Response.Send(DefaultPages.Pages[404].Content, _Token).ConfigureAwait(false);
+                    if (ctx.Response.ChunkedTransfer)
+                        await ctx.Response.SendFinalChunk(Encoding.UTF8.GetBytes(DefaultPages.Pages[404].Content), _Token).ConfigureAwait(false);
+                    else
+                        await ctx.Response.Send(DefaultPages.Pages[404].Content, _Token).ConfigureAwait(false);
                     return;
                 }
 
@@ -633,7 +636,10 @@ namespace WatsonWebserver.Lite
 
                     try
                     {
-                        await ctx.Response.Send(DefaultPages.Pages[500].Content, _Token).ConfigureAwait(false);
+                        if (ctx.Response.ChunkedTransfer)
+                            await ctx.Response.SendFinalChunk(Encoding.UTF8.GetBytes(DefaultPages.Pages[500].Content), _Token).ConfigureAwait(false);
+                        else
+                            await ctx.Response.Send(DefaultPages.Pages[500].Content, _Token).ConfigureAwait(false);
                     }
                     catch
                     {
@@ -657,7 +663,10 @@ namespace WatsonWebserver.Lite
                     {
                         ctx.Response.StatusCode = 500;
                         ctx.Response.ContentType = DefaultPages.Pages[500].ContentType;
-                        await ctx.Response.Send(DefaultPages.Pages[500].Content).ConfigureAwait(false);
+                        if (ctx.Response.ChunkedTransfer)
+                            await ctx.Response.SendFinalChunk(Encoding.UTF8.GetBytes(DefaultPages.Pages[500].Content)).ConfigureAwait(false);
+                        else
+                            await ctx.Response.Send(DefaultPages.Pages[500].Content).ConfigureAwait(false);
                     }
 
                     ctx.Timestamp.End = DateTime.UtcNow;

--- a/src/WatsonWebserver/Webserver.cs
+++ b/src/WatsonWebserver/Webserver.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Text.Json.Serialization;
 using WatsonWebserver.Core;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace WatsonWebserver
 {
@@ -554,7 +555,10 @@ namespace WatsonWebserver
                             {
                                 ctx.Response.StatusCode = 404;
                                 ctx.Response.ContentType = DefaultPages.Pages[404].ContentType;
-                                await ctx.Response.Send(DefaultPages.Pages[404].Content).ConfigureAwait(false);
+                                if (ctx.Response.ChunkedTransfer)
+                                    await ctx.Response.SendFinalChunk(Encoding.UTF8.GetBytes(DefaultPages.Pages[404].Content)).ConfigureAwait(false);
+                                else
+                                    await ctx.Response.Send(DefaultPages.Pages[404].Content).ConfigureAwait(false);
                                 return;
                             }
 
@@ -564,7 +568,10 @@ namespace WatsonWebserver
                         {
                             ctx.Response.StatusCode = 500;
                             ctx.Response.ContentType = DefaultPages.Pages[500].ContentType;
-                            await ctx.Response.Send(DefaultPages.Pages[500].Content).ConfigureAwait(false);
+                            if (ctx.Response.ChunkedTransfer)
+                                await ctx.Response.SendFinalChunk(Encoding.UTF8.GetBytes(DefaultPages.Pages[500].Content)).ConfigureAwait(false);
+                            else
+                                await ctx.Response.Send(DefaultPages.Pages[500].Content).ConfigureAwait(false);
                             Events.HandleExceptionEncountered(this, new ExceptionEventArgs(ctx, eInner));
                         }
                         finally
@@ -577,7 +584,10 @@ namespace WatsonWebserver
                                 {
                                     ctx.Response.StatusCode = 500;
                                     ctx.Response.ContentType = DefaultPages.Pages[500].ContentType;
-                                    await ctx.Response.Send(DefaultPages.Pages[500].Content).ConfigureAwait(false);
+                                    if (ctx.Response.ChunkedTransfer)
+                                        await ctx.Response.SendFinalChunk(Encoding.UTF8.GetBytes(DefaultPages.Pages[500].Content)).ConfigureAwait(false);
+                                    else
+                                        await ctx.Response.Send(DefaultPages.Pages[500].Content).ConfigureAwait(false);
                                 }
 
                                 ctx.Timestamp.End = DateTime.UtcNow;


### PR DESCRIPTION
Fixes a bug where booth Watson backends can hard crash in a specific scenario.

The scenario in question is a streaming application (not yet available) that uses chunked encoding with FFMpeg, but like described in this issue tracker : https://github.com/dotnet/WatsonWebserver/issues/135 the server can send some 500 Internal Server Error responses in the middle (which client ignore of course, so harmless) in case of a non-standard streaming use. 

So we effectively now use chunck encoding if, by mistake, server send one of these 500 Internal Server Error while in a chunked stream session.