### PR TITLE
Fix invalid host header when creating multiple webserver instances

### DIFF
--- a/src/WatsonWebserver.Lite/Webserver.cs
+++ b/src/WatsonWebserver.Lite/Webserver.cs
@@ -69,7 +69,7 @@ namespace WatsonWebserver.Lite
             if (settings == null) settings = new WebserverSettings(); 
 
             Settings = settings;
-            WebserverConstants.HeaderHost = settings.Hostname + ":" + settings.Port;
+            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = settings.Hostname + ":" + settings.Port;
             Routes = new WebserverRoutes(Settings, defaultRoute);
 
             _Header = "[Webserver " + Settings.Prefix + "] ";

--- a/src/WatsonWebserver/Webserver.cs
+++ b/src/WatsonWebserver/Webserver.cs
@@ -69,7 +69,7 @@ namespace WatsonWebserver
             if (settings == null) settings = new WebserverSettings();
 
             Settings = settings;
-            WebserverConstants.HeaderHost = settings.Hostname + ":" + settings.Port;
+            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = settings.Hostname + ":" + settings.Port;
             Routes.Default = defaultRoute;
 
             _Header = "[Webserver " + Settings.Prefix + "] ";


### PR DESCRIPTION
Hi,

I found a bug in webserver code. When creating multiple instances of webserver in same process ( eg. same host, different port), WebserverConstants.HeaderHost is overriden. Originally it has "Host" value, but in `Webserver` constructor is then overriden by host:port value from settings.

It results in invalid value for DefaultHeaders in next instance of  Webserver and throws when handling routes, because HeaderHost is used as a key for default headers at first init. Its a bug, but if its intended - i think its bad practice to use global vars in that way.

This pull request simply sets default header host at webserver constructor manually.