### PR TITLE
Watson Lite: Fix Headers Not Being Parsed Correctly

### DIFF
--- a/src/WatsonWebserver.Lite/HttpRequest.cs
+++ b/src/WatsonWebserver.Lite/HttpRequest.cs
@@ -350,41 +350,40 @@ namespace WatsonWebserver.Lite
                 {
                     #region Subsequent-Line
 
-                    string[] headerLine = headers[i].Split(':');
-                    if (headerLine.Length == 2)
+                    int headerLineSplit = headers[i].IndexOf(':');
+                    string key = headers[i].Substring(0, headerLineSplit).Trim();
+                    string val = headers[i].Substring(headerLineSplit + 1).Trim();
+                    
+
+                    if (String.IsNullOrEmpty(key)) continue;
+                    string keyEval = key.ToLower();
+
+                    if (keyEval.Equals("keep-alive"))
                     {
-                        string key = headerLine[0].Trim();
-                        string val = headerLine[1].Trim();
-
-                        if (String.IsNullOrEmpty(key)) continue;
-                        string keyEval = key.ToLower();
-
-                        if (keyEval.Equals("keep-alive"))
-                        {
-                            Keepalive = Convert.ToBoolean(val);
-                        }
-                        else if (keyEval.Equals("user-agent"))
-                        {
-                            Useragent = val;
-                        }
-                        else if (keyEval.Equals("content-length"))
-                        {
-                            ContentLength = Convert.ToInt32(val);
-                        }
-                        else if (keyEval.Equals("content-type"))
-                        {
-                            ContentType = val;
-                        }
-                        else if (keyEval.ToLower().Equals("x-amz-content-sha256"))
-                        {
-                            if (val.ToLower().Contains("streaming"))
-                            {
-                                ChunkedTransfer = true;
-                            }
-                        }
-
-                        Headers.Add(key, val);
+                        Keepalive = Convert.ToBoolean(val);
                     }
+                    else if (keyEval.Equals("user-agent"))
+                    {
+                        Useragent = val;
+                    }
+                    else if (keyEval.Equals("content-length"))
+                    {
+                        ContentLength = Convert.ToInt32(val);
+                    }
+                    else if (keyEval.Equals("content-type"))
+                    {
+                        ContentType = val;
+                    }
+                    else if (keyEval.ToLower().Equals("x-amz-content-sha256"))
+                    {
+                        if (val.ToLower().Contains("streaming"))
+                        {
+                            ChunkedTransfer = true;
+                        }
+                    }
+
+                    Headers.Add(key, val);
+                    
 
                     #endregion
                 }


### PR DESCRIPTION
## Info

This fix to the watson lite header parsing code allows for header values to contain colons.
Previously, headers values would be ignored if they had colons in them.
This will help with parsing certain headers and will make it more in line with the HTTP/1.1 spec.

## Motivation

Browsers usually sent a `Host` header to the server, which sometimes includes a colon to delimit the port number:
`Host: 127.0.0.1:8080`. Without this fix, the `Host` header is ignored. With this fix, the header is parsed correctly.
